### PR TITLE
Create Renderer constructor function

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -1,0 +1,16 @@
+const $ = require('jquery');
+
+function Renderer (board) {
+  this.board = board; 
+}
+
+Renderer.prototype.renderBoard = function () {
+  return $(`<div class='board'></div>`);
+};
+
+Renderer.prototype.renderBoardAndAppendTo = function (target) {
+  this.renderBoard().appendTo(target);
+  return this;
+};
+
+module.exports = Renderer;

--- a/package.json
+++ b/package.json
@@ -32,5 +32,8 @@
     "style-loader": "^0.12.3",
     "webpack": "^1.10.1",
     "webpack-dev-server": "^1.10.1"
+  },
+  "dependencies": {
+    "jquery": "^2.1.4"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,1 +1,2 @@
 require('./board-test');
+require('./renderer-test');

--- a/test/renderer-test.js
+++ b/test/renderer-test.js
@@ -1,0 +1,63 @@
+const assert = require('assert');
+const Renderer = require('../lib/renderer');
+const Board = require('../lib/board');
+const $ = require('jquery');
+
+describe('Renderer', function () {
+  it('should exist', function () {
+    let renderer = new Renderer();
+
+    assert(renderer);
+  });
+
+  it('has a board object', function () {
+    let board = new Board();
+    let renderer = new Renderer(board);
+    
+    assert(Board.prototype.isPrototypeOf(renderer.board));
+  });
+
+  describe('renderBoard', function () {
+
+    it('should have a renderBoard method', function () {
+      let board = new Board();
+      let renderer = new Renderer(board);      
+
+      assert(renderer.renderBoard);
+    });
+
+    it('should a render with a class of board', function () {
+      let board = new Board();
+      let renderer = new Renderer(board);      
+      let renderedBoard = renderer.renderBoard();
+
+      assert.equal(renderedBoard.length, 1);
+      assert.equal(renderedBoard[0].className, 'board');
+    });
+  });
+
+  describe('renderBoardAndAppendTo', function () {
+
+    beforeEach(function () {
+      this.container = $('<div></div>').addClass('container');
+    });
+
+    it('should have a renderBoardAndAppendTo', function () {
+      let board = new Board();
+      let renderer = new Renderer(board);      
+      
+      assert(renderer.renderBoardAndAppendTo);
+    });
+
+    it('should renderBoardAndAppendTo a target', function () {
+      let board = new Board();
+      let renderer = new Renderer(board);      
+      let container = this.container;
+      renderer.renderBoardAndAppendTo(container);
+
+      assert.equal(container.find('.board').length, 1);
+    });
+
+  });
+
+});


### PR DESCRIPTION
Why:
- Renderer object should render a given Board object to the html page.

This change addresses the need by:
- Adding Renderer constructor function
- Adding #renderBoard
- Adding #renderBoardAndAppendTo
- Adding jquery to renderer.js
