### PR TITLE
Add #shiftLeft method to Board object

### DIFF
--- a/lib/board.js
+++ b/lib/board.js
@@ -20,7 +20,7 @@ Board.prototype.freeSpaces = function () {
     row.forEach(function (space, columnIndex) {
       if (space == null) {
 
-        freeSpaces.push([columnIndex, rowIndex]);
+        freeSpaces.push([rowIndex, columnIndex]);
       }
     });
   });
@@ -37,8 +37,8 @@ Board.prototype.addTile = function () {
 };
 
 Board.prototype.insertTile = function (tile) {
-  var columnIndex = tile.position[0];
-  var rowIndex = tile.position[1];
+  var rowIndex = tile.position[0];
+  var columnIndex = tile.position[1];
   this.spaces[rowIndex][columnIndex] = tile;
 };
 
@@ -48,35 +48,35 @@ Board.prototype.addTwoTiles = function () {
 };
 
 Board.prototype.insertTileAt = function (position, tile) {
-  var columnIndex = position[0];
-  var rowIndex = position[1];
+  var rowIndex = position[0];
+  var columnIndex = position[1];
   tile.position = position;
-  this.spaces[columnIndex][rowIndex] = tile;
+  this.spaces[rowIndex][columnIndex] = tile;
 };
 
 Board.prototype.checkSpaceAt = function (position) {
   var positionValidity = this.isPositionValid(position);
   if ( positionValidity ) {
-    var columnIndex = position[0];
-    var rowIndex = position[1];
-    return this.spaces[rowIndex][columnIndex]; 
+    var rowIndex = position[0];
+    var columnIndex = position[1];
+    return this.spaces[rowIndex][columnIndex];
   } else {
     return "No preceding space."
   }
 };
 
 Board.prototype.isPositionValid = function (position) {
-  if ( this.isColumnValid(position[0]) && this.isRowValid(position[1]) ) {
+  if ( this.isRowValid(position[0] ) && this.isColumnValid(position[1]) ) {
     return true;
   } else {
     return false;
   }
 };
 
-Board.prototype.isColumnValid = function (columnIndex) {
-  var width = this.spaces[0].length;
+Board.prototype.isRowValid = function (rowIndex) {
+  var height = this.spaces.length;
 
-  if ( (columnIndex >= 0) && (columnIndex < width) ) {
+  if ( (rowIndex >= 0) && (rowIndex < height) ) {
     return true;
   }  else {
     return false;
@@ -84,10 +84,10 @@ Board.prototype.isColumnValid = function (columnIndex) {
 
 };
 
-Board.prototype.isRowValid = function (rowIndex) {
-  var height = this.spaces.length;
+Board.prototype.isColumnValid = function (columnIndex) {
+  var width = this.spaces[0].length;
 
-  if ( (rowIndex >= 0) && (rowIndex < height) ) {
+  if ( (columnIndex >= 0) && (columnIndex < width) ) {
     return true;
   }  else {
     return false;
@@ -106,7 +106,7 @@ Board.prototype.updateTilePositions = function () {
   this.spaces.forEach( function (row, rowIndex) {
     row.forEach(function (space, columnIndex) {
       if (space instanceof Tile) {
-        space.position = [columnIndex, rowIndex]
+        space.position = [rowIndex, columnIndex]
       }
     });
   });

--- a/lib/board.js
+++ b/lib/board.js
@@ -95,4 +95,21 @@ Board.prototype.isRowValid = function (rowIndex) {
 
 };
 
+Board.prototype.shiftLeft = function () {
+  this.spaces = this.spaces.map(function (row) {
+    return row.sort();
+  });
+  this.updateTilePositions();
+};
+
+Board.prototype.updateTilePositions = function () {
+  this.spaces.forEach( function (row, rowIndex) {
+    row.forEach(function (space, columnIndex) {
+      if (space instanceof Tile) {
+        space.position = [columnIndex, rowIndex]
+      }
+    });
+  });
+};
+
 module.exports = Board;

--- a/lib/tile.js
+++ b/lib/tile.js
@@ -1,13 +1,13 @@
-function Tile (position, board) {
-  this.board = board;
-  this.value = 2;
+function Tile (position, board, value) {
   this.position = position;
+  this.board = board;
+  this.value = value;
 }
 
 Tile.prototype.checkPrecedingSpace = function () {
-  var columnIndex = this.position[0];
-  var rowIndex = this.position[1];
-  return this.board.checkSpaceAt([columnIndex - 1, rowIndex]);
+  var rowIndex = this.position[0];
+  var columnIndex = this.position[1];
+  return this.board.checkSpaceAt([rowIndex, columnIndex - 1]);
 };
 
 module.exports = Tile;

--- a/test/board-test.js
+++ b/test/board-test.js
@@ -75,11 +75,24 @@ describe('the board', function () {
   describe('insertTileAt', function () {
     it('should insert a tile at a given position on board', function () {
       let board = new Board('game');
-      let tile = new Tile(board);
+      let tile = new Tile('position', board);
       board.insertTileAt([1, 1], tile);
-      
+
       assert.deepEqual(tile.position, [1, 1]);
       assert.equal(board.spaces[1][1], tile);
+    });
+  });
+
+  describe('shiftLeft', function () {
+    it('should shift one tile to the left edge', function () {
+      let board = new Board('game');
+      let tile = new Tile('position', board);
+      board.insertTileAt([1, 1], tile);
+
+      board.shiftLeft();
+
+      assert.deepEqual(tile.position, [0, 1]);
+      assert.equal(board.spaces[1][0], tile);
     });
   });
 

--- a/test/board-test.js
+++ b/test/board-test.js
@@ -41,10 +41,10 @@ describe('the board', function () {
       let freeSpaces = board.freeSpaces();
 
       // [ columnIndex, rowIndex ]
-      let expected = [ [0, 0], [1, 0], [2, 0], [3, 0],
-                       [0, 1], [1, 1], [2, 1], [3, 1],
-                       [0, 2], [1, 2], [2, 2], [3, 2],
-                       [0, 3], [1, 3], [2, 3], [3, 3] ];
+      let expected = [ [0, 0], [0, 1], [0, 2], [0, 3],
+                       [1, 0], [1, 1], [1, 2], [1, 3],
+                       [2, 0], [2, 1], [2, 2], [2, 3],
+                       [3, 0], [3, 1], [3, 2], [3, 3] ];
 
       assert.deepEqual(freeSpaces, expected);
 
@@ -87,13 +87,86 @@ describe('the board', function () {
     it('should shift one tile to the left edge', function () {
       let board = new Board('game');
       let tile = new Tile('position', board);
-      board.insertTileAt([1, 1], tile);
+      board.insertTileAt([0, 1], tile);
+
 
       board.shiftLeft();
 
-      assert.deepEqual(tile.position, [0, 1]);
-      assert.equal(board.spaces[1][0], tile);
+      assert.deepEqual(tile.position, [0, 0]);
+      assert.equal(board.spaces[0][0], tile);
+    });
+
+    it('should shift two tiles in the same row to the left', function () {
+      let board = new Board('game');
+      let tile1 = new Tile('position', board, 2);
+      let tile2 = new Tile('position', board, 4);
+
+      board.insertTileAt([1, 1], tile1);
+      board.insertTileAt([1, 2], tile2);
+
+      board.shiftLeft();
+
+      debugger;
+
+      assert.deepEqual(tile1.position, [1, 0]);
+      assert.deepEqual(tile2.position, [1, 1]);
+      assert.deepEqual(tile1.value, 2);
+      assert.deepEqual(tile2.value, 4);
+      assert.equal(board.spaces[1][0], tile1);
+      assert.equal(board.spaces[1][1], tile2);
+    });
+
+    it('should shift two tiles in different rows to the left', function () {
+      let board = new Board('game');
+      let tile1 = new Tile('position', board, 2);
+      let tile2 = new Tile('position', board, 2);
+
+      board.insertTileAt([1, 1], tile1);
+      board.insertTileAt([2, 1], tile2);
+
+      board.shiftLeft();
+
+      assert.deepEqual(tile1.position, [1, 0]);
+      assert.deepEqual(tile2.position, [2, 0]);
+      assert.deepEqual(tile1.value, 2);
+      assert.deepEqual(tile2.value, 2);
+      assert.equal(board.spaces[1][0], tile1);
+      assert.equal(board.spaces[2][0], tile2);
+    });
+
+    it('should shift many tiles in different rows and columns to the left,', function () {
+      let board = new Board('game');
+      let tile1 = new Tile('position', board, 1);
+      let tile2 = new Tile('position', board, 2);
+      let tile3 = new Tile('position', board, 3);
+      let tile4 = new Tile('position', board, 4);
+      let tile5 = new Tile('position', board, 5);
+
+      board.insertTileAt([1, 1], tile1);
+      board.insertTileAt([2, 1], tile2);
+      board.insertTileAt([0, 3], tile3);
+      board.insertTileAt([3, 2], tile4);
+      board.insertTileAt([3, 3], tile5);
+
+      board.shiftLeft();
+
+      assert.deepEqual(tile1.position, [1, 0]);
+      assert.deepEqual(tile2.position, [2, 0]);
+      assert.deepEqual(tile3.position, [0, 0]);
+      assert.deepEqual(tile4.position, [3, 0]);
+      assert.deepEqual(tile5.position, [3, 1]);
+      assert.deepEqual(tile1.value, 1);
+      assert.deepEqual(tile2.value, 2);
+      assert.deepEqual(tile3.value, 3);
+      assert.deepEqual(tile4.value, 4);
+      assert.deepEqual(tile5.value, 5);
+      assert.equal(board.spaces[1][0], tile1);
+      assert.equal(board.spaces[2][0], tile2);
+      assert.equal(board.spaces[0][0], tile3);
+      assert.equal(board.spaces[3][0], tile4);
+      assert.equal(board.spaces[3][1], tile5);
     });
   });
+
 
 });

--- a/test/board-test.js
+++ b/test/board-test.js
@@ -106,8 +106,6 @@ describe('the board', function () {
 
       board.shiftLeft();
 
-      debugger;
-
       assert.deepEqual(tile1.position, [1, 0]);
       assert.deepEqual(tile2.position, [1, 1]);
       assert.deepEqual(tile1.value, 2);

--- a/test/tile-test.js
+++ b/test/tile-test.js
@@ -3,11 +3,6 @@ const Tile = require('../lib/tile');
 const Board = require('../lib/board');
 
 describe('the tile', function () {
-  it('should instantiate with a value of 2', function () {
-    let tile = new Tile();
-
-    assert.equal(tile.value, 2);
-  });
 
   it('should accept position as an argument', function () {
     let tile = new Tile([1,3]);
@@ -20,6 +15,13 @@ describe('the tile', function () {
     let tile = new Tile('position', board);
 
     assert.equal(tile.board, board);
+  });
+
+  it('should accept a value as an argument', function () {
+    let board = new Board();
+    let tile = new Tile('position', board, 4);
+
+    assert.equal(tile.value, 4);
   });
 
   describe('checkPrecedingSpace', function () {
@@ -35,7 +37,7 @@ describe('the tile', function () {
     it('should return preceding element if tile is not adjacent to left edge', function () {
       let board = new Board();
       let tile = new Tile(null, board);
-      board.insertTileAt([1, 0], tile);
+      board.insertTileAt([0, 1], tile);
       let precedingSpace = tile.checkPrecedingSpace();
 
       assert.equal(precedingSpace, null);


### PR DESCRIPTION
Why:

Tiles should move towards the left edge and all null spaces should
append to the end of the row

This change addresses the need by:
- Adding #updateTilePositions method to Board object
