### PR TITLE
Add #moveDown to Board class

### DIFF
--- a/lib/board.js
+++ b/lib/board.js
@@ -123,6 +123,15 @@ Board.prototype.moveUp = function () {
   this.updateTilePositions();
 };
 
+Board.prototype.moveDown = function () {
+  this.spaces = this.transpose(this.spaces); 
+  this.reverseSpaces(); 
+  this.moveLeft();
+  this.reverseSpaces();  
+  this.spaces = this.transpose(this.spaces);
+  this.updateTilePositions();
+};
+
 Board.prototype.collapse = function () {
   var self = this;
 
@@ -153,7 +162,7 @@ Board.prototype.transpose = function (spaces) {
 
   // Calculate the width and height of the Array
   var w = spaces.length ? spaces.length : 0,
-    h = spaces[0] instanceof Array ? spaces[0].length : 0;
+  h = spaces[0] instanceof Array ? spaces[0].length : 0;
 
   // In case it is a zero matrix, no transpose routine needed.
   if (h === 0 || w === 0) {
@@ -175,6 +184,12 @@ Board.prototype.transpose = function (spaces) {
   }
 
   return transposedData;
+};
+
+Board.prototype.reverseSpaces = function () {
+  this.spaces = this.spaces.map(function (row) {
+    return row.reverse();
+  });
 };
 
 module.exports = Board;

--- a/test/board-test.js
+++ b/test/board-test.js
@@ -372,4 +372,80 @@ describe('the board', function () {
     });
   });
 
+  describe('moveDown', function () {
+    it('should collapse two tiles of equal value in one column', function () {
+      let board = new Board('game');
+      let tile1 = new Tile('position', board, 2);
+      let tile2 = new Tile('position', board, 2);
+
+      board.insertTileAt([0, 0], tile1);
+      board.insertTileAt([1, 0], tile2);
+
+      board.moveDown();
+
+      assert.deepEqual(tile2.position, [3, 0]);
+      assert.equal(tile2.value, 4);
+      assert.equal(board.freeSpaces().length, 15);
+      assert.equal(board.spaces[3][0], tile2);
+    });
+
+    it('should collapse two columns of two tiles each', function () {
+      let board = new Board('game');
+      let tile1 = new Tile('position', board, 2);
+      let tile2 = new Tile('position', board, 2);
+      let tile3 = new Tile('position', board, 2);
+      let tile4 = new Tile('position', board, 2);
+
+      board.insertTileAt([0, 0], tile1);
+      board.insertTileAt([1, 0], tile2);
+      board.insertTileAt([0, 1], tile3);
+      board.insertTileAt([1, 1], tile4);
+
+      board.moveDown();
+
+      assert.deepEqual(tile2.position, [3, 0]);
+      assert.deepEqual(tile4.position, [3, 1]);
+      assert.equal(tile2.value, 4);
+      assert.equal(tile4.value, 4);
+      assert.equal(board.freeSpaces().length, 14);
+      assert.equal(board.spaces[3][0], tile2);
+      assert.equal(board.spaces[3][1], tile4);
+    });
+
+    it('should collapse multiple columns with multiple tiles each', function () {
+      let board = new Board('game');
+      let tile1 = new Tile('position', board, 2);
+      let tile2 = new Tile('position', board, 2);
+      let tile3 = new Tile('position', board, 4);
+      let tile4 = new Tile('position', board, 4);
+      let tile5 = new Tile('position', board, 8);
+      let tile6 = new Tile('position', board, 10);
+
+      board.insertTileAt([0, 0], tile1);
+      board.insertTileAt([1, 0], tile2);
+      board.insertTileAt([0, 1], tile3);
+      board.insertTileAt([1, 1], tile4);
+      board.insertTileAt([0, 2], tile5);
+      board.insertTileAt([1, 2], tile6);
+
+      board.moveDown();
+
+      assert.deepEqual(tile2.position, [3, 0]);
+      assert.deepEqual(tile4.position, [3, 1]);
+      assert.deepEqual(tile5.position, [2, 2]);
+      assert.deepEqual(tile6.position, [3, 2]);
+      assert.equal(tile2.value, 4);
+      assert.equal(tile4.value, 8);
+      assert.equal(tile5.value, 8);
+      assert.equal(tile6.value, 10);
+
+      assert.equal(board.freeSpaces().length, 12);
+      assert.equal(board.spaces[3][0], tile2);
+      assert.equal(board.spaces[3][1], tile4);
+      assert.equal(board.spaces[2][2], tile5);
+      assert.equal(board.spaces[3][2], tile6);
+    });
+
+  });
+
 });


### PR DESCRIPTION
Why:
- Tiles should move to the bottom of the board when a player moves down.

This change addresses the need by:
- Adding a #moveDown method to Board class
- Adding a #reverseSpaces method to Board class
