### PR TITLE
Add #gameOver method to Game class

### DIFF
--- a/lib/game.js
+++ b/lib/game.js
@@ -11,4 +11,57 @@ Game.prototype.updateScore = function (points) {
   this.score += points;
 };
 
+Game.prototype.gameOver = function () {
+  return this.noPossibleCombinations() && this.board.freeSpaces().length == 0;
+};
+
+Game.prototype.noPossibleCombinations = function () {
+  // check left, check right, check up, down
+
+  return this.checkLeftForCombinations() &&
+         this.checkRightForCombinations() &&
+         this.checkUpForCombinations() &&
+         this.checkDownForCombinations();
+};
+
+Game.prototype.checkLeftForCombinations = function () {
+  var currentScore = this.score;
+
+  this.board.moveLeft();
+
+  var newScore = this.score;
+  this.score = currentScore;
+  return newScore == currentScore;
+};
+
+Game.prototype.checkRightForCombinations = function () {
+  var currentScore = this.score;
+
+  this.board.moveRight();
+
+  var newScore = this.score;
+  this.score = currentScore;
+  return newScore == currentScore;
+};
+
+Game.prototype.checkUpForCombinations = function () {
+  var currentScore = this.score;
+
+  this.board.moveUp();
+
+  var newScore = this.score;
+  this.score = currentScore;
+  return newScore == currentScore;
+};
+
+Game.prototype.checkDownForCombinations = function () {
+  var currentScore = this.score;
+
+  this.board.moveDown();
+
+  var newScore = this.score;
+  this.score = currentScore;
+  return newScore == currentScore;
+};
+
 module.exports = Game;

--- a/test/game-test.js
+++ b/test/game-test.js
@@ -1,6 +1,7 @@
 const assert = require('assert');
 const Game = require('../lib/game');
 const Board = require('../lib/board');
+const Tile = require('../lib/tile');
 
 describe('Game', function () {
   it('should have a score property', function () {
@@ -27,6 +28,25 @@ describe('Game', function () {
       game.updateScore('4');
 
       assert.equal(game.score, 4); 
+    });
+  });
+
+  describe('gameOver', function () {
+    it('should return true if no moves are possible', function () {
+      let game = new Game();
+      let board = game.board;
+
+      let tile1 = new Tile('position', board, 2);
+      let tile2 = new Tile('position', board, 4);
+      let tile3 = new Tile('position', board, 8);
+      let tile4 = new Tile('position', board, 16);
+
+      board.spaces = [[tile1, tile2, tile3, tile4],
+                      [tile4, tile3, tile2, tile1],
+                      [tile1, tile2, tile3, tile4],
+                      [tile4, tile3, tile2, tile1]];
+
+      assert(game.gameOver());
     });
   });
 });


### PR DESCRIPTION
Why:

When there are no possible moves or free spaces, the game should end

This addresses the need by:
- Adding #gameOver method to Game class
- Adding #noPossibleCombinations method to Game class
- Adding #checkLeftForCombination method to Game class
- Adding #checkRightForCombination method to Game class
- Adding #checkDownForCombination method to Game class
- Adding #checkUpForCombination method to Game class
