### PR TITLE
Add #addTilesTo method to Renderer class

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,31 +11,31 @@
     <div class="game-container">
         <div class="grid-container">
             <div class="row-container">
-                <div class="cell-container"></div>
-                <div class="cell-container"></div>
-                <div class="cell-container"></div>
-                <div class="cell-container"></div>
+                <div id="0-0" class="cell-container"></div>
+                <div id="0-1" class="cell-container"></div>
+                <div id="0-2" class="cell-container"></div>
+                <div id="0-3" class="cell-container"></div>
             </div>
 
             <div class="row-container">
-                <div class="cell-container"></div>
-                <div class="cell-container"></div>
-                <div class="cell-container"></div>
-                <div class="cell-container"></div>
+                <div id="1-0" class="cell-container"></div>
+                <div id="1-1" class="cell-container"></div>
+                <div id="1-2" class="cell-container"></div>
+                <div id="1-3" class="cell-container"></div>
             </div>
 
             <div class="row-container">
-                <div class="cell-container"></div>
-                <div class="cell-container"></div>
-                <div class="cell-container"></div>
-                <div class="cell-container"></div>
+                <div id="2-0" class="cell-container"></div>
+                <div id="2-1" class="cell-container"></div>
+                <div id="2-2" class="cell-container"></div>
+                <div id="2-3" class="cell-container"></div>
             </div>
 
             <div class="row-container">
-                <div class="cell-container"></div>
-                <div class="cell-container"></div>
-                <div class="cell-container"></div>
-                <div class="cell-container"></div>
+                <div id="3-0" class="cell-container"></div>
+                <div id="3-1" class="cell-container"></div>
+                <div id="3-2" class="cell-container"></div>
+                <div id="3-3" class="cell-container"></div>
             </div>
         </div>
 

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -1,17 +1,29 @@
 const $ = require('jquery');
 const _ = require('lodash');
 
-function Renderer(board) {
-  this.board = board;
+function Renderer(game) {
+  this.game = game;
 }
 
+/*
 Renderer.prototype.renderTiles = function () {
   var board = $(`<div class='tile'></div>`);
 
   return board;
 };
+*/
+
+Renderer.prototype.addTilesTo = function (target) {
+  var tiles = this.game.collectAllTiles();
+  tiles.forEach( function (tile) {
+    target.find('#' + tile.rowIndex() + '-' + tile.columnIndex())
+      .addClass('tile-' + tile.value)
+      .text(tile.value);
+  });
+};
 
 Renderer.prototype.renderBoardAndAppendTo = function (target) {
+
   this.renderTiles().appendTo(target);
   return this;
 };

--- a/lib/tile.js
+++ b/lib/tile.js
@@ -10,4 +10,12 @@ Tile.prototype.checkPrecedingSpace = function () {
   return this.board.checkSpaceAt(rowIndex, columnIndex - 1);
 };
 
+Tile.prototype.rowIndex = function () {
+  return this.position[0];
+};
+
+Tile.prototype.columnIndex = function () {
+  return this.position[1];
+};
+
 module.exports = Tile;

--- a/test/renderer-test.js
+++ b/test/renderer-test.js
@@ -1,8 +1,8 @@
 const assert = require('assert');
 const Renderer = require('../lib/renderer');
-const Board = require('../lib/board');
+const Game = require('../lib/game');
+const Tile = require('../lib/tile');
 const $ = require('jquery');
-//const sinon = require('sinon');
 
 describe('Renderer', function () {
   it('should exist', function () {
@@ -11,59 +11,61 @@ describe('Renderer', function () {
     assert(renderer);
   });
 
-  it('has a board object', function () {
-    let board = new Board();
-    let renderer = new Renderer(board);
+  it('has a game object', function () {
+    let game = new Game();
+    let renderer = new Renderer(game);
     
-    assert(Board.prototype.isPrototypeOf(renderer.board));
+    assert(Game.prototype.isPrototypeOf(renderer.game));
   });
 
-  describe('renderTiles', function () {
+  describe('addTilesTo', function () {
+    it('adds class and appends value to correct cell-container', function () {
+      let game = new Game();
+      let renderer = new Renderer(game);
+      let board = game.board;
+      let tile = new Tile([0, 0], board, 2);
+      let container = $('<div></div>').addClass('container');
+      let cellContainer = $('<div></div>').attr('id', '0-0');
 
-    it('should have a renderTiles method', function () {
-      let board = new Board();
-      let renderer = new Renderer(board);      
+      board.insertTileAt([0, 0], tile);
+      container.append(cellContainer);
 
-      assert(renderer.renderTiles);
-    });
-
-    it('should render with a class of tile', function () {
-      let board = new Board();
-      let renderer = new Renderer(board);      
-      let renderedBoard = renderer.renderTiles();
-
-      assert.equal(renderedBoard.length, 1);
-      assert.equal(renderedBoard[0].className, 'tile');
-    });
-
-  });
-
-  describe.skip('renderTile', function () {
-    // code goes here
-  });
-
-  describe('renderBoardAndAppendTo', function () {
-
-    beforeEach(function () {
-      this.container = $('<div></div>').addClass('container');
-    });
-
-    it('should have a renderBoardAndAppendTo', function () {
-      let board = new Board();
-      let renderer = new Renderer(board);      
+      renderer.addTilesTo(container);
       
-      assert(renderer.renderBoardAndAppendTo);
+      assert.equal(cellContainer.text(), "2");
+      assert.equal(container.find('#0-0').attr('class'), 'tile-2');
     });
 
-    it('should renderBoardAndAppendTo a target', function () {
-      let board = new Board();
-      let renderer = new Renderer(board);      
-      let container = this.container;
-      renderer.renderBoardAndAppendTo(container);
+    it('adds class and appends value for multiple tiles', function () {
+      let game = new Game();
+      let renderer = new Renderer(game);
+      let board = game.board;
 
-      assert.equal(container.find('.tile').length, 1);
+      let tile1 = new Tile([0, 0], board, 2);
+      let tile2 = new Tile([1, 1], board, 4);
+      let tile3 = new Tile([2, 2], board, 8);
+
+      let container = $('<div></div>').addClass('container');
+      let cellContainer1 = $('<div></div>').attr('id', '0-0');
+      let cellContainer2 = $('<div></div>').attr('id', '1-1');
+      let cellContainer3 = $('<div></div>').attr('id', '2-2');     
+
+      board.insertTileAt([0, 0], tile1);
+      board.insertTileAt([1, 1], tile2);
+      board.insertTileAt([2, 2], tile3);
+
+      container.append(cellContainer1)
+        .append(cellContainer2)
+        .append(cellContainer3);
+
+      renderer.addTilesTo(container);
+      
+      assert.equal(cellContainer1.text(), "2");
+      assert.equal(container.find('#0-0').attr('class'), 'tile-2');
+      assert.equal(cellContainer2.text(), "4");
+      assert.equal(container.find('#1-1').attr('class'), 'tile-4');
+      assert.equal(cellContainer3.text(), "8");
+      assert.equal(container.find('#2-2').attr('class'), 'tile-8');
     });
-
   });
-
 });


### PR DESCRIPTION
Why:
- To add tile classes and tile values to html elements given a target.

This change addresses the need by:
- Adding #addTilesTo method to Renderer class
- Deleted unnecessary methods and tests from previous iterations
- Adding ids to cell-container divs on index.html
- Adding #rowIndex and #columnIndex virtual attributes to Tile class
