### PR TITLE
Fixing bug that added tile if board did not change

### DIFF
--- a/lib/board.js
+++ b/lib/board.js
@@ -8,6 +8,8 @@ function Board(game) {
     [null, null, null, null],
     [null, null, null, null]];
 
+  this.previousFreeSpaces = [];
+
   this.game = game;
 
 }
@@ -29,12 +31,13 @@ Board.prototype.freeSpaces = function () {
 
 Board.prototype.addTile = function () {
   var possibleValues = [2, 4];
-  
   var tile = new Tile(null, this);
   var freeSpaces = this.freeSpaces();
   var randomFreeSpace = freeSpaces[Math.floor(Math.random() * freeSpaces.length)];
+
   tile.position = randomFreeSpace;
   tile.value = possibleValues[Math.floor(Math.random() * possibleValues.length)];
+
   this.insertTile(tile);
   return tile;
 };

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -20,33 +20,37 @@ function detectUserInput() {
   document.onkeydown = function (e) {
     switch (e.keyCode) {
       case 37:
+        gameRenderer.game.board.previousFreeSpaces = _.cloneDeep(currentFreeSpaces());
         gameRenderer.game.board.moveLeft();
         syncBoard();
         break;
       case 38:
+        gameRenderer.game.board.previousFreeSpaces = _.cloneDeep(currentFreeSpaces());
         gameRenderer.game.board.moveUp();
         syncBoard();
         break;
       case 39:
+        gameRenderer.game.board.previousFreeSpaces = _.cloneDeep(currentFreeSpaces());
         gameRenderer.game.board.moveRight();
         syncBoard();
         break;
       case 40:
+        gameRenderer.game.board.previousFreeSpaces = _.cloneDeep(currentFreeSpaces());
         gameRenderer.game.board.moveDown();
         syncBoard();
         break;
     }
 
-   document.onkeyup = function (e) {
-     if ( gameRenderer.game.isGameWon() ) {
-      alert('You win!');
-      stopListeningToUserInput();
-     }
-     else if ( gameRenderer.game.isGameOver() ) {
-      alert('Game over!');
-      stopListeningToUserInput();
-     }
-   }
+    document.onkeyup = function (e) {
+      if (gameRenderer.game.isGameWon()) {
+        alert('You win!');
+        stopListeningToUserInput();
+      }
+      else if (gameRenderer.game.isGameOver()) {
+        alert('Game over!');
+        stopListeningToUserInput();
+      }
+    }
   };
 
 }
@@ -54,10 +58,42 @@ function detectUserInput() {
 function syncBoard() {
   var target = $('.container');
 
-  gameRenderer.clearAllTileClasses(target)
-    .clearAllValues(target)
-    .addRandomTile()
-    .addTilesTo(target);
+  if (freeSpacesChanged()) {
+    gameRenderer.clearAllTileClasses(target)
+      .addRandomTile()
+      .clearAllValues(target)
+      .addTilesTo(target);
+  } else {
+    gameRenderer.clearAllTileClasses(target)
+      .clearAllValues(target)
+      .addTilesTo(target);
+  }
+}
+
+function freeSpacesChanged() {
+
+  var spaceComparison = previousFreeSpaces().map(function (position, index) {
+    if (currentFreeSpaces()[index][0] == position[0] &&
+      currentFreeSpaces()[index][1] == position[1]) {
+      return false;
+    } else {
+      return true;
+    }
+  });
+
+  if (_.includes(spaceComparison, true)) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+function currentFreeSpaces() {
+  return gameRenderer.game.board.freeSpaces();
+}
+
+function previousFreeSpaces() {
+  return gameRenderer.game.board.previousFreeSpaces;
 }
 
 function stopListeningToUserInput() {


### PR DESCRIPTION
Why:

The board should not add a tile if the player's move does not change any
of the tiles' positions, or combine two or more tiles.

This change addresses the need by:
- Adding #previousFreeSpaces property to Board class
- Adding #freeSpacesChanged function to runner.js
- Saving #previousFreeSpaces before a move is made in #detectUserInput in
  runner.js
- changing #syncBoard implementation in runner.js to only call
  #addRandomTile method if #freeSpacesChanged evaluates to true
